### PR TITLE
new logging adapter proposal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libterminus
-version = 19.2.1
+version = 20.6.0-dev
 description = Library that contains a logging adapter and a pipeline
 author = Evoniners
 author_email = dev@evonove.it

--- a/terminus/logutils.py
+++ b/terminus/logutils.py
@@ -10,11 +10,11 @@ def get_user_from_jwt(token):
     """
     Decode the JWT to read the payload
     """
-    decoded_payload = jwt.decode(token, verify=False, algorithms=['HS256'])
-    if 'username' in decoded_payload:
-        return decoded_payload['username']
+    decoded_payload = jwt.decode(token, verify=False, algorithms=["HS256"])
+    if "username" in decoded_payload:
+        return decoded_payload["username"]
     else:
-        return decoded_payload['user_id']
+        return decoded_payload["user_id"]
 
 
 class RecordingAdapter(logging.LoggerAdapter):
@@ -22,24 +22,26 @@ class RecordingAdapter(logging.LoggerAdapter):
     This adapter adds extra fields to a LogRecord
     """
 
+    metadata = {}
+
+    @classmethod
+    def set_metadata(cls, **kwargs):
+        cls.metadata = {}
+
+        if "jwt" in kwargs:
+            jwt = kwargs.pop("jwt")
+            cls.metadata["user"] = get_user_from_jwt(jwt)
+
+        cls.metadata.update(kwargs)
+
+    @classmethod
+    def clear_metadata(cls):
+        cls.metadata = {}
+
     def process(self, msg, kwargs):
-        extra = kwargs.get('extra', {})
-        if 'recording' in kwargs:
-            extra['device_id'] = kwargs['recording']['device_id']
-            extra['recording_id'] = kwargs['recording']['id']
-            # add to logging the JWT payload
-            extra['jwt'] = get_user_from_jwt(kwargs['recording']['jwt'])
-
-        elif 'topic' in kwargs:
-            extra['topic'] = kwargs['topic']
-        elif 'device_id' in kwargs:
-            extra['device_id'] = kwargs['device_id']
-        elif 'recording_id' in kwargs:
-            extra['recording_id'] = kwargs['recording_id']
-        elif 'jwt' in kwargs:
-            extra['jwt'] = get_user_from_jwt(kwargs['jwt'])
-
-        return msg, {'extra': extra}
+        extra = kwargs.get("extra", {})
+        extra.update(**self.metadata)
+        return msg, {"extra": extra}
 
 
 class JSONFormatter(jsonlogger.JsonFormatter):
@@ -48,17 +50,18 @@ class JSONFormatter(jsonlogger.JsonFormatter):
     We use datadog for logging, and the datadog agent can't decode the
     default python pickled LogRecord. It can't decode a packed json either.
     """
+
     service = None
 
     def __init__(self, *args, **kwargs):
-        self.service = kwargs.pop('service', 'unknown service')
+        self.service = kwargs.pop("service", "unknown service")
 
         super().__init__(*args, **kwargs)
 
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
 
-        log_record['service'] = self.service
+        log_record["service"] = self.service
 
 
 class JSONDatagramHandler(DatagramHandler):
@@ -70,26 +73,26 @@ class JSONDatagramHandler(DatagramHandler):
         super().__init__(host, port)
 
         supported_keys = [
-            'asctime',
-            'created',
-            'filename',
-            'funcName',
-            'levelname',
-            'levelno',
-            'lineno',
-            'module',
-            'msecs',
-            'message',
-            'name',
-            'pathname',
-            'process',
-            'processName',
-            'relativeCreated',
-            'thread',
-            'threadName'
+            "asctime",
+            "created",
+            "filename",
+            "funcName",
+            "levelname",
+            "levelno",
+            "lineno",
+            "module",
+            "msecs",
+            "message",
+            "name",
+            "pathname",
+            "process",
+            "processName",
+            "relativeCreated",
+            "thread",
+            "threadName",
         ]
-        custom_format = ' '.join('%({0:s})'.format(k) for k in supported_keys)
+        custom_format = " ".join("%({0:s})".format(k) for k in supported_keys)
         self.formatter = JSONFormatter(custom_format, service=service)
 
     def makePickle(self, record):
-        return self.formatter.format(record).encode() + b'\n'
+        return self.formatter.format(record).encode() + b"\n"


### PR DESCRIPTION
### What it does
Changes the `RecordingAdapter` class so that it exposes a generic metadata API which allows to set only once the extra metadata we would like to send to our logging system.

Example
```python
logger = RecordingAdapter(logging.getLogger(__name__), {})
logger.info("Hello!")

RecordingAdapter.set_metadata(foo="a")
logger.info("Hello!")
```

This is not thread safe, but in our use case it works since we can set recording metadata only once, at the beginning of the processing of a recording, and then reset at the end.

For example in mallow
```python
for msg in received_messages:
    logger.info("Message received")
    device_data = device_data_pb2.DeviceData(zlib.decompress(msg.message.data))
    RecordingAdapter.set_metadata(recording_id=uuid.UUID(bytes=device_data.recording_id), jwt=device_data.jwt)
    
    # do your processing and log whenever you need to
    
    RecordingAdapter.clear_metadata()
```


